### PR TITLE
Make timestamp output format and timezone configurable

### DIFF
--- a/pgmacs.el
+++ b/pgmacs.el
@@ -190,6 +190,17 @@ concerning a specific table, rather than the entire database."
   :type 'hook
   :group 'pgmacs)
 
+(defcustom pgmacs-timestamp-format "%Y-%m-%dT%T"
+  "Format string to be used for timestamp/timestamptz/datetime output."
+  :type 'string
+  :group 'pgmacs)
+
+(defcustom pgmacs-timestamp-zone nil
+  "Time zone to be used for timestamp/timestamptz/datetime output,
+e.g. 'UTC' or 'Europe/Berlin'. Nil for local OS timezone."
+  :type 'string
+  :group 'pgmacs)
+
 ;; TODO: it would be cleaner to hold these all in a pgmacs-connection object.
 (defvar-local pgmacs--con nil)
 (defvar-local pgmacs--table nil)
@@ -480,10 +491,10 @@ Applies format string FMT to ARGS."
   (cond ((string= type-name "date")
          (lambda (val) (format-time-string "%Y-%m-%d" val)))
         ((or (string= type-name "timestamp")
-            (string= type-name "timestamptz")
-	    (string= type-name "datetime"))
+             (string= type-name "timestamptz")
+             (string= type-name "datetime"))
          ;; these are represented as a `decode-time' structure
-         (lambda (val) (format-time-string "%Y-%m-%dT%T" val)))
+         (lambda (val) (format-time-string pgmacs-timestamp-format val pgmacs-timestamp-zone)))
         ((or (string= type-name "text")
              (string= type-name "varchar")
              (string= type-name "name"))


### PR DESCRIPTION
Hi Eric,

now that we have proper timestamp handling in place in pg-el (thanks for accepting!), I would like to propose this small addition: format and zone of timestamp output could be made customizable by use of two additional variables (default stays like before). What do you think?