### PR TITLE
Fix wrong order of arguments reading from properties list

### DIFF
--- a/pgmacs.el
+++ b/pgmacs.el
@@ -1628,7 +1628,7 @@ Uses PostgreSQL connection CON."
 ;; estimating the row count. Otherwise, use a naïve COUNT(*) query which is expensive but always
 ;; returns valid results.
 (defun pgmacs--estimate-row-count (table)
-  (let ((db-size (get 'database-size pgmacs--con)))
+  (let ((db-size (get 'pgmacs--con 'database-size)))
     (if (and db-size (> db-size pgmacs-large-database-threshold))
         (pgmacs--estimate-row-count/fast table)
       (pgmacs--estimate-row-count/expensive table))))


### PR DESCRIPTION
This call would always return nil for database-size, thus still leading to expensive row count estimation even for huge DBs.