### PR TITLE
Fix Empty package name

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -26,7 +26,7 @@ export INSTALL_EL := '''
     (unless (package-installed-p 'pg)
        (package-vc-install "https://github.com/emarsden/pg-el" nil nil 'pg))
     (unless (package-installed-p 'pgmacs)
-       (package-vc-install "https://github.com/emarsden/pgmacs"))
+       (package-vc-install "https://github.com/emarsden/pgmacs" nil nil 'pgmacs))
 
     (require 'pgmacs)
 '''

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ from the git repository, as well as the [pg-el dependency](https://github.com/em
     (unless (package-installed-p 'pg)
        (package-vc-install "https://github.com/emarsden/pg-el" nil nil 'pg))
     (unless (package-installed-p 'pgmacs)
-       (package-vc-install "https://github.com/emarsden/pgmacs"))
+       (package-vc-install "https://github.com/emarsden/pgmacs" nil nil 'pgmacs))
 
     (require 'pgmacs)
 

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -21,7 +21,7 @@ from the git repository, as well as the dependency [pg-el](https://github.com/em
 (unless (package-installed-p 'pg)
    (package-vc-install "https://github.com/emarsden/pg-el/" nil nil 'pg))
 (unless (package-installed-p 'pgmacs)
-   (package-vc-install "https://github.com/emarsden/pgmacs/"))
+   (package-vc-install "https://github.com/emarsden/pgmacs/" nil nil 'pgmacs))
 
 (require 'pgmacs)
 ```


### PR DESCRIPTION
Fixes the installation instructions for `package-vc-install`.

With "GNU Emacs 29.4 (build 1, x86_64-redhat-linux-gnu, GTK+ Version 3.24.43, cairo version 1.18.2) of 2025-01-03", it says "Empty package name" and does nothing.